### PR TITLE
Blockクラスに全ブロックの定義を追加

### DIFF
--- a/app/src/main/java/com/t_robop/yuusuke/a01_spica_android/Block.java
+++ b/app/src/main/java/com/t_robop/yuusuke/a01_spica_android/Block.java
@@ -3,8 +3,48 @@ package com.t_robop.yuusuke.a01_spica_android;
 public final class Block {
     // TODO こんな感じの実装がしたい
     // FIXME ここでResourceファイルを使いたい
-    public final class FrontBlock{
+    public final class FrontBlock {
         public static final String id = "01";
         public static final String name = "すすむ";
+    }
+
+    public final class BackBlock {
+        public static final String id = "02";
+    }
+
+    public final class LeftBlock {
+        public static final String id = "03";
+    }
+
+    public final class RightBlock {
+        public static final String id = "04";
+    }
+
+    public final class ForStartBlock {
+        public static final String id = "05";
+    }
+
+    public final class ForEndBlock {
+        public static final String id = "06";
+    }
+
+    public final class IfStartBlock {
+        public static final String id = "07";
+    }
+
+    public final class IfEndBlock {
+        public static final String id = "08";
+    }
+
+    public final class BreakBlock {
+        public static final String id = "09";
+    }
+
+    public final class StartBlock {
+        public static final String id = "10";
+    }
+
+    public final class EndBlock {
+        public static final String id = "11";
     }
 }


### PR DESCRIPTION
## Overview (このPRでなにをやってるのかの説明)
- とりあえず全ブロックの定義追加、idだけ定義

## Issue (解決するissueのリンクがあれば貼る)
- 

各ブロック内で他に定義するもの(ブロックの文言とか)は、まだ仕様詰めきれてないので別PRにて対応予定

@TaigaNatto 
今までenumのSpicaBlockでブロックの種類を見て処理分けているコードとかは、このBlockクラスのidを見るように置き換えって認識で合ってる？