### PR TITLE
UIBlockModelクラスで必要な定義を追加

### DIFF
--- a/app/src/main/java/com/t_robop/yuusuke/a01_spica_android/model/UIBlockModel.java
+++ b/app/src/main/java/com/t_robop/yuusuke/a01_spica_android/model/UIBlockModel.java
@@ -3,8 +3,16 @@ package com.t_robop.yuusuke.a01_spica_android.model;
 import com.t_robop.yuusuke.a01_spica_android.Config;
 
 public class UIBlockModel extends BlockModel {
-    int pos;
-    boolean isInLoop;
+    private int pos;
+    private boolean isInLoop;
+
+    public UIBlockModel(){}
+
+    public UIBlockModel(int pos, int ifState, boolean isInLoop) {
+        this.pos = pos;
+        super.setIfState(ifState);
+        this.isInLoop = isInLoop;
+    }
 
     public int getPos() {
         return pos;
@@ -23,18 +31,35 @@ public class UIBlockModel extends BlockModel {
     }
 
     // 走行秒数
+    public float getTime() {
+        return getValue();
+    }
+
     public void setTime(float time) {
         setValue(time);
     }
 
     // ループ回数
+    public int getLoopNum() {
+        return (int) getValue();
+    }
+
     public void setLoopNum(int num) {
         setValue(num);
     }
 
     // しきい値
+    public float getThreshold() {
+        return getValue();
+    }
+
     public void setThreshold(float value) {
         setValue(value);
+    }
+
+    // power
+    public int getPower() {
+        return getOption();
     }
 
     // おそい
@@ -52,6 +77,11 @@ public class UIBlockModel extends BlockModel {
         setOption(Config.HIGH_POWER);
     }
 
+    // センサー計測値より大きいか小さいか、どちらを指定したか取得
+    public int getIfOperator() {
+        return getOption();
+    }
+
     // センサー値より大きい
     public void setSensorAbove() {
         setOption(Config.SENSOR_ABOVE);
@@ -63,8 +93,18 @@ public class UIBlockModel extends BlockModel {
     }
 
     @Override
+    public float getValue() {
+        return super.getValue();
+    }
+
+    @Override
     public void setValue(float value) {
         super.setValue(value);
+    }
+
+    @Override
+    public int getOption() {
+        return super.getOption();
     }
 
     @Override


### PR DESCRIPTION
## Overview (このPRでなにをやってるのかの説明)
- モデルリプレースに応じて必要なコンストラクタ、getterを追加定義
- メンバ変数がprivateじゃなかったので修正

## Issue (解決するissueのリンクがあれば貼る)
- 
